### PR TITLE
[Fixes #53] no duplicate handling when write into a database a second time

### DIFF
--- a/load-config_mssql-testdb.sh
+++ b/load-config_mssql-testdb.sh
@@ -11,6 +11,6 @@ export LOGSTAR_STATIONS=""
 # database conf
 export LOGSTAR_DB_USER="SA"
 export LOGSTAR_DB_PASS="MyPassword!"
-export LOGSTAR_DB="logstar"
+export LOGSTAR_DB_DBNAME="logstar"
 export LOGSTAR_DB_DRIVER="ODBC Driver 17 for SQL Server"
 export LOGSTAR_DB_PORT="1433"

--- a/load-config_psql-testdb.sh
+++ b/load-config_psql-testdb.sh
@@ -11,7 +11,7 @@ export LOGSTAR_STATIONS=""
 # database conf
 export LOGSTAR_DB_USER="postgres"
 export LOGSTAR_DB_PASS="postgres"
-export LOGSTAR_DB="logstar"
+export LOGSTAR_DB_DBNAME="logstar"
 export LOGSTAR_DB_HOST="localhost"
 export LOGSTAR_DB_DRIVER="PostgreSQL"
 export LOGSTAR_DB_PORT="5432"


### PR DESCRIPTION

<!-- 
Thanks for creating this pull request 🤗 | Danke fürs erstellen eines Pull-Requests

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one. || Bitte vergewissere dich das der pull request auf eine Typ (Dokumentaion, neue Funktionalität, Bug etc.) beschränkt ist. Öffne liebe mehrere Pull-Requests anstatt einen großen Pull-Request zu öffnen.-->

Closes #53

## 📑 Description
logstar-stream now creates databases.tables with primary key constrains and does no insert on duplication. 

**THIS PATCH ONLY WORKS FOR POSTGRESQL ATM**
